### PR TITLE
Return error message as is

### DIFF
--- a/lib/closeio/error.rb
+++ b/lib/closeio/error.rb
@@ -21,7 +21,7 @@ module FaradayMiddleware
       when 504
         raise Closeio::GatewayTimeout, env.body
       when ERROR_STATUSES
-        raise Closeio::Error, "#{env.status}: #{env.body}"
+        raise Closeio::Error, env.body
       end
     end
   end

--- a/lib/closeio/version.rb
+++ b/lib/closeio/version.rb
@@ -1,3 +1,3 @@
 module Closeio
-  VERSION = '3.3.0'.freeze
+  VERSION = '3.4.0'.freeze
 end


### PR DESCRIPTION
Error message must always be parseable.